### PR TITLE
Allow empty tag argument, e.g. [quote=][/quote]

### DIFF
--- a/postmarkup/parser.py
+++ b/postmarkup/parser.py
@@ -842,7 +842,7 @@ class PostMarkup(object):
                     while post[end_pos] == u' ':
                         end_pos += 1
                     if post[end_pos] != u'"':
-                        end_pos = post_find(u']', end_pos + 1)
+                        end_pos = post_find(u']', end_pos)
                         if end_pos == -1:
                             return
                         yield TOKEN_TAG, post[pos:end_pos + 1], pos, end_pos + 1

--- a/postmarkup/tests.py
+++ b/postmarkup/tests.py
@@ -73,6 +73,17 @@ class TestPostmarkup(unittest.TestCase):
         for test, result in tests:
             self.assertEqual(markup(test), result)
 
+    def test_quote(self):
+        markup = postmarkup.create(annotate_links=False)
+
+        tests = [(u'[quote]some text[/quote]', u'<blockquote>some text</blockquote>'),
+                 (u'[quote="user=name"]jibber[/quote]', u'<blockquote><em>user=name</em><br/>jibber</blockquote>'),
+                 (u'[quote=]jabber[/quote]', u'<blockquote>jabber</blockquote>'),
+                 ]
+
+        for test, result in tests:
+            self.assertEqual(markup(test), result)
+
     def test_unknowntags(self):
         """Test unknown tags pass through correctly"""
         markup = postmarkup.create(annotate_links=False)


### PR DESCRIPTION
Previously [quote=]foo[/quote] was translated into

<blockquote><em>]foo[/quote</em><br/></blockquote>


PS: Thanks for taking care of the GitHub conversion. :)

This work was sponsored by [voicecom.ee](https://voicecom.ee).
